### PR TITLE
use env variable

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,6 +2,6 @@ BasedOnStyle: Google
 IndentWidth: 4
 
 Language: Cpp
-ColumnLimit: 200
+ColumnLimit: 150
 AllowShortFunctionsOnASingleLine : None
 


### PR DESCRIPTION
the env variable ard_ipc will be append to the name of shared memory and mutexes this allows multiple instances of arduino code to be run.