### PR TITLE
changes to build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ else()
 endif()
 
 if (NOT ((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")))
-    message(WARNING "Unsupported compiler")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        message(WARNING "Unsupported compiler")
+    else()
+        message(FATAL_ERROR "Unsupported compiler")
+    endif()
 else()
     message(VERBOSE "compiler okay")
     # if compiler okay then warning flags can be added if they are turned on

--- a/miscellaneous/arduinoCode/CMakeLists.txt
+++ b/miscellaneous/arduinoCode/CMakeLists.txt
@@ -1,12 +1,10 @@
 set(PROJECT_SOURCES
         main.cpp
-        sample.hpp
 )
 
 add_library(
         inner
-        STATIC
-        sample_private.hpp
+        OBJECT
         sample.cpp
 )
 

--- a/miscellaneous/arduinoCode/sample_private.hpp
+++ b/miscellaneous/arduinoCode/sample_private.hpp
@@ -1,11 +1,13 @@
 #include <limits.h>
+#include <math.h>
 #include <signal.h>
+#include <stdint.h>
 #include <stdlib.h>
 
-#include "../../library/ArduinoWrapper/adwr.hpp"
+#include <adwr.hpp>
 
 #pragma GCC push_options
-#pragma GCC optimize ("O0")
+#pragma GCC optimize("O0")
 
 HardwareSerial Serial = HardwareSerial(12);
 

--- a/src/library/ArduinoWrapper/Adafruit_RGBLCDShield.hpp
+++ b/src/library/ArduinoWrapper/Adafruit_RGBLCDShield.hpp
@@ -2,6 +2,9 @@
     Code taken from Adafruit_RGBLCDShield.h at https://github.com/adafruit/Adafruit-RGB-LCD-Shield-Library
 */
 
+#ifndef LCD_H
+#define LCD_h
+
 #define BUTTON_UP 0x08      //!< Up button
 #define BUTTON_DOWN 0x04    //!< Down button
 #define BUTTON_LEFT 0x10    //!< Left button
@@ -11,12 +14,10 @@
 
 #include "Print.hpp"
 
-#ifndef LCD_H
-#define LCD_h
-
 class Adafruit_RGBLCDShield : public Print {
    public:
-    void init(uint8_t fourbitmode, uint8_t rs, uint8_t rw, uint8_t enable, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5, uint8_t d6, uint8_t d7);
+    void init(uint8_t fourbitmode, uint8_t rs, uint8_t rw, uint8_t enable, uint8_t d0, uint8_t d1, uint8_t d2, uint8_t d3, uint8_t d4, uint8_t d5,
+              uint8_t d6, uint8_t d7);
 
     Adafruit_RGBLCDShield();
 

--- a/src/library/ArduinoWrapper/CMakeLists.txt
+++ b/src/library/ArduinoWrapper/CMakeLists.txt
@@ -21,7 +21,7 @@ set(adwr_reuse_sources
 
 add_library(
     adwr_reuse
-    STATIC
+    OBJECT
     ${adwr_reuse_sources}
 )
 

--- a/src/library/ArduinoWrapper/HardwareSerial.hpp
+++ b/src/library/ArduinoWrapper/HardwareSerial.hpp
@@ -24,12 +24,12 @@
     Modified 18 October 2022 by Melvin Pynadath
 */
 
+#ifndef SERIAL_H
+#define SERIAL_H
+
 #include <stdint.h>
 
 #include "Stream.hpp"
-
-#ifndef SERIAL_H
-#define SERIAL_H
 
 class HardwareSerial : public Stream {
    public:

--- a/src/library/ArduinoWrapper/Print.hpp
+++ b/src/library/ArduinoWrapper/Print.hpp
@@ -21,6 +21,9 @@
     Modified 18 October 2022 by Melvin Pynadath
 */
 
+#ifndef CUS_PRINT_H
+#define CUS_PRINT_H
+
 #include <stdint.h>
 
 #include <cstring>
@@ -39,9 +42,6 @@ using String = std::string;
 #else
 #include "string.hpp"
 #endif
-
-#ifndef CUS_PRINT_H
-#define CUS_PRINT_H
 
 class Print {
    private:

--- a/src/library/ArduinoWrapper/Stream.hpp
+++ b/src/library/ArduinoWrapper/Stream.hpp
@@ -22,10 +22,10 @@
     Modified 18 October 2022 by Melvin Pynadath
 */
 
-#include "Print.hpp"
-
 #ifndef STREAM_H
 #define STREAM_H
+
+#include "Print.hpp"
 
 // This enumeration provides the lookahead options for parseInt(), parseFloat()
 // The rules set out here are used until either the first valid character is found

--- a/src/library/ArduinoWrapper/character.hpp
+++ b/src/library/ArduinoWrapper/character.hpp
@@ -21,12 +21,12 @@
     Modified 18 October 2022 by Melvin Pynadath
  */
 
+#ifndef CHAR_H
+#define CHAR_H
+
 #include <ctype.h>
 
 #include "def.hpp"
-
-#ifndef CHAR_H
-#define CHAR_H
 
 inline boolean isAlphaNumeric(int c) {
     return (isalnum(c) == 0 ? false : true);

--- a/src/library/ArduinoWrapper/def.hpp
+++ b/src/library/ArduinoWrapper/def.hpp
@@ -1,8 +1,7 @@
-
-#include <stdint.h>
-
 #ifndef DEF_H
 #define DEF_H
+
+#include <stdint.h>
 
 #define DEC 10
 #define HEX 16

--- a/src/library/ArduinoWrapper/math.hpp
+++ b/src/library/ArduinoWrapper/math.hpp
@@ -21,10 +21,10 @@
     Modified 18 October 2022 by Melvin Pynadath
 */
 
-#include "def.hpp"
-
 #ifndef MATH_H
 #define MATH_H
+
+#include "def.hpp"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
 #define max(a, b) ((a) > (b) ? (a) : (b))

--- a/src/library/lcd/CMakeLists.txt
+++ b/src/library/lcd/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost COMPONENTS system REQUIRED)
 
 add_library(

--- a/src/library/lcd/LcdIPC.hpp
+++ b/src/library/lcd/LcdIPC.hpp
@@ -17,6 +17,9 @@
     along with ArduinoWrapper.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#ifndef LCD_IPC_H
+#define LCD_IPC_H
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -27,9 +30,6 @@
 #define BUTTON_LEFT 0x10    //!< Left button
 #define BUTTON_RIGHT 0x02   //!< Right button
 #define BUTTON_SELECT 0x01  //!< Select button
-
-#ifndef LCD_IPC_H
-#define LCD_IPC_H
 
 /**
  * @brief the LCD communication class \n

--- a/src/library/serial/CMakeLists.txt
+++ b/src/library/serial/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS system)
 
 add_library(

--- a/src/library/serial/SerialIPC.hpp
+++ b/src/library/serial/SerialIPC.hpp
@@ -17,6 +17,9 @@
     along with ArduinoWrapper.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+#ifndef SERIAL_IPC_H
+#define SERIAL_IPC_H
+
 #include <cstdint>
 #include <cstdio>
 
@@ -135,3 +138,5 @@ class SerialIPC {
         return instance;
     }
 };
+
+#endif


### PR DESCRIPTION
includes now inside the include guards
boost use static
terminate build if compiler not clang or gcc or msvc changed adwr_reuse to object library